### PR TITLE
Sort tags as versions

### DIFF
--- a/changelog/ios-beta-changelog.sh
+++ b/changelog/ios-beta-changelog.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
-PENULTIMATE_APP_STORE_VERSION=$(git tag -l --sort=-refname "7.[0-9]" | head -n 2 | tail -n 1)
-TAGS=$(git tag -l --sort=-refname --contains $PENULTIMATE_APP_STORE_VERSION "7.*-*" | sed '$d')
+PENULTIMATE_APP_STORE_VERSION=$(git tag -l --sort=-version:refname "7.[0-9]" | head -n 2 | tail -n 1)
+TAGS=$(git tag -l --sort=-version:refname --contains $PENULTIMATE_APP_STORE_VERSION "7.*-*" | sed '$d')
 
 echo -e "master\n$TAGS" | sed 'p;1d;$d' | xargs -n 2 ./ios-live.sh
 

--- a/changelog/ios-beta-changelog.sh
+++ b/changelog/ios-beta-changelog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-PENULTIMATE_APP_STORE_VERSION=$(git tag -l --sort=-version:refname "7.[0-9]" | head -n 2 | tail -n 1)
+PENULTIMATE_APP_STORE_VERSION=$(git tag -l --sort=-version:refname "7.[0-9]" "7.[0-9][0-9]" | head -n 2 | tail -n 1)
 TAGS=$(git tag -l --sort=-version:refname --contains $PENULTIMATE_APP_STORE_VERSION "7.*-*" | sed '$d')
 
 echo -e "master\n$TAGS" | sed 'p;1d;$d' | xargs -n 2 ./ios-live.sh

--- a/changelog/ios-release-changelog.sh
+++ b/changelog/ios-release-changelog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-TAGS=$(git tag -l --sort=-refname "7.*-*" "6.*-*" | grep -o '[6,7]\.[0-9]*' | uniq | xargs -I {} sh -c 'git tag -l --sort=-refname "{}-*" | head -1')
+TAGS=$(git tag -l --sort=-version:refname "7.*-*" "6.*-*" | grep -o '[6,7]\.[0-9]*' | uniq | xargs -I {} sh -c 'git tag -l --sort=-refname "{}-*" | head -1')
 
 echo -e "$TAGS" | sed 'p;1d;$d' | xargs -n 2 ./ios-live.sh
 


### PR DESCRIPTION
The iOS devs noticed the beta changelog has not really been working since we've moved to versions 7.10 and 7.11. This could be because the script is not sorting the tags the right way.
Apparently it's possible to use `version:refname` to have the tags treated as versions when sorting. 
If this is correct we should also apply it to the app store changelog (Or whatever the correct fix would be)
