### PR TITLE
Rename iOS Manifest plist

### DIFF
--- a/builds/index.html
+++ b/builds/index.html
@@ -83,7 +83,7 @@
             <a :href="releases.iosEditions.development.teamcity">{{ releases.iosEditions.development.date }}</a>
             <a :href="releases.iosEditions.development.github">#{{ releases.iosEditions.development.sha1 }}</a></p>
           <p class="text-center"><a class="btn btn-primary btn-lg btn-success"
-              href="itms-services://?action=download-manifest&url=https://s3-eu-west-1.amazonaws.com/builds.gutools.co.uk/debug.plist"
+              href="itms-services://?action=download-manifest&url=https://s3-eu-west-1.amazonaws.com/builds.gutools.co.uk/editions-ios-manifest.plist"
               role="button">Install 🍎 build</a></p>
         </div>
       </div>


### PR DESCRIPTION
Because `debug.plist` is a bit vague.