### PR TITLE
LIVE-2070: Refine s3 bucket policy permissions

### DIFF
--- a/releases/releases-cloud-formation.yaml
+++ b/releases/releases-cloud-formation.yaml
@@ -37,7 +37,9 @@ Resources:
         - Sid: IPAllow
           Effect: Allow
           Principal: "*"
-          Action: s3:*
+          Action:
+            - s3:ListAllMyBuckets
+            - s3:GetObject
           Resource: arn:aws:s3:::releases.gutools.co.uk/*
           Condition:
             IpAddress:

--- a/releases/releases-cloud-formation.yaml
+++ b/releases/releases-cloud-formation.yaml
@@ -40,6 +40,7 @@ Resources:
           Action:
             - s3:ListAllMyBuckets
             - s3:GetObject
+            - s3:GetBucketLocation
           Resource: arn:aws:s3:::releases.gutools.co.uk/*
           Condition:
             IpAddress:

--- a/releases/releases-cloud-formation.yaml
+++ b/releases/releases-cloud-formation.yaml
@@ -38,15 +38,25 @@ Resources:
           Effect: Allow
           Principal: "*"
           Action:
-            - s3:ListAllMyBuckets
             - s3:GetObject
-            - s3:GetBucketLocation
           Resource: arn:aws:s3:::releases.gutools.co.uk/*
           Condition:
             IpAddress:
               aws:SourceIp:
               - 77.91.248.0/21
               - 162.213.134.128/26
+        - Sid: IPAllow
+          Effect: Allow
+          Principal: "*"
+          Action:
+            - s3:ListBucket
+            - s3:GetBucketLocation
+          Resource: arn:aws:s3:::releases.gutools.co.uk
+          Condition:
+            IpAddress:
+              aws:SourceIp:
+                - 77.91.248.0/21
+                - 162.213.134.128/26
         - Sid: "3"
           Effect: Allow
           Principal:


### PR DESCRIPTION
## What does this change?
Only allow the s3 bucket to get and list objects rather than give it all permissions. This fixes a security vulnerbility flagged by [AWS](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#s3-6-remediation)

## How to test
This has been tested on the endpoint by checking downloads can still happen: https://releases.gutools.co.uk/
