### PR TITLE
LIVE-2068: Refine s3 bucket policy permissions 

### DIFF
--- a/builds/builds-cloud-formation.yaml
+++ b/builds/builds-cloud-formation.yaml
@@ -37,13 +37,26 @@ Resources:
         - Sid: IPAllow
           Effect: Allow
           Principal: "*"
-          Action: s3:*
+          Action:
+            - s3:GetObject
           Resource: arn:aws:s3:::builds.gutools.co.uk/*
           Condition:
             IpAddress:
               aws:SourceIp:
               - 77.91.248.0/21
               - 162.213.134.128/26
+        - Sid: IPAllow
+          Effect: Allow
+          Principal: "*"
+          Action:
+            - s3:ListBucket
+            - s3:GetBucketLocation
+          Resource: arn:aws:s3:::releases.gutools.co.uk
+          Condition:
+            IpAddress:
+              aws:SourceIp:
+                - 77.91.248.0/21
+                - 162.213.134.128/26
         - Sid: "3"
           Effect: Allow
           Principal:


### PR DESCRIPTION
## What does this change?
Only allow the s3 bucket to get and list objects rather than give it all permissions. This fixes a security vulnerbility flagged by [AWS](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#s3-6-remediation)

## How to test
Hitting the endpoint still works, and it still downloads a build: https://builds.gutools.co.uk/