### PR TITLE
Bump transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,10 @@
   "scripts": {
     "start": "node ./node_modules/live-server/live-server.js releases/",
     "start-builds": "node ./node_modules/live-server/live-server.js builds/"
+  },
+  "overrides": {
+    "http-auth": "3.2.4",
+    "unset-value": "2.0.1",
+    "glob-parent": "5.1.2"
   }
 }


### PR DESCRIPTION
## What does this change?

There are some transitive dependencies identified by snyk as having security vulnerabilities. This PR overrides the versions of the vulnerable transitive dependencies. 

I ran `snyk test` locally and there were no vulnerabilities. Also, after `npm i` the generated package.json contained only references to the newly specified versions.
